### PR TITLE
fix: Cert timing bug for L2s

### DIFF
--- a/src/bridge/EigenDABlobVerifierL1.sol
+++ b/src/bridge/EigenDABlobVerifierL1.sol
@@ -2,9 +2,13 @@
 pragma solidity ^0.8.9;
 
 import "./IRollupManager.sol";
+import {
+    ExpiredEigenDACert
+} from "../libraries/Error.sol";
 
 contract EigenDABlobVerifierL1 is IRollupManager {
     IEigenDAServiceManager public immutable EIGEN_DA_SERVICE_MANAGER;
+    uint256 internal constant MAX_CERTIFICATE_DRIFT = 100; 
 
     constructor(address _eigenDAServiceManager) {
         EIGEN_DA_SERVICE_MANAGER = IEigenDAServiceManager(_eigenDAServiceManager);
@@ -14,6 +18,23 @@ contract EigenDABlobVerifierL1 is IRollupManager {
         IEigenDAServiceManager.BlobHeader calldata blobHeader,
         EigenDARollupUtils.BlobVerificationProof calldata blobVerificationProof
     ) external view {
+        /*
+            Verify that the certificate is less than 2 epochs old from the L1 reference block number
+            This is to prevent timing attacks where the sequencer could submit an expired or close to expired
+            certificate which could impact liveness of full nodes as well as the safety of the bridge
+        */
+        if (
+            (blobVerificationProof.batchMetadata.confirmationBlockNumber +
+                MAX_CERTIFICATE_DRIFT) < block.number
+        ) {
+            revert ExpiredEigenDACert(
+                block.number,
+                blobVerificationProof.batchMetadata.confirmationBlockNumber +
+                    MAX_CERTIFICATE_DRIFT
+            );
+        }
+
+
         EigenDARollupUtils.verifyBlob(blobHeader, EIGEN_DA_SERVICE_MANAGER, blobVerificationProof);
     }
 }

--- a/src/libraries/Error.sol
+++ b/src/libraries/Error.sol
@@ -170,6 +170,9 @@ error BadSequencerMessageNumber(uint256 stored, uint256 received);
 /// @dev Tried to create an already valid Data Availability Service keyset
 error AlreadyValidDASKeyset(bytes32);
 
+/// @dev The EigenDA certificate provided to the inbox was stale
+error ExpiredEigenDACert(uint256 currentBlock, uint256 l1ReferenceBlock);
+
 /// @dev Tried to use or invalidate an already invalid Data Availability Service keyset
 error NoSuchKeyset(bytes32);
 

--- a/test/foundry/EigenDABlobVerifierL1.t.sol
+++ b/test/foundry/EigenDABlobVerifierL1.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "forge-std/Test.sol";
+import "../../src/bridge/EigenDABlobVerifierL1.sol";
+import "../../src/libraries/Error.sol";
+import {EigenDARollupUtils} from "@eigenda/eigenda-utils/libraries/EigenDARollupUtils.sol";
+import {IEigenDAServiceManager} from "@eigenda/eigenda-utils/interfaces/IEigenDAServiceManager.sol";
+import {BN254} from "@eigenda/eigenda-utils/libraries/BN254.sol";
+import {SequencerInboxTest} from "./SequencerInbox.t.sol";
+import {
+    ExpiredEigenDACert
+} from "../../src/libraries/Error.sol";
+ 
+contract EigenDABlobVerifierL1Test is Test {
+    EigenDABlobVerifierL1 public verifier;
+    IEigenDAServiceManager dummyEigenDAServiceManager = IEigenDAServiceManager(address(138));
+
+    SequencerInboxTest inboxTest = new SequencerInboxTest();
+
+    function setUp() public {
+        // Deploy the verifier contract with a mock EigenDA Service Manager
+        verifier = new EigenDABlobVerifierL1(address(dummyEigenDAServiceManager));
+    }
+
+    function testCertificateTooOld() public {
+        (
+            IEigenDAServiceManager.BlobHeader memory blobHeader,
+            EigenDARollupUtils.BlobVerificationProof memory blobVerificationProof
+        ) = inboxTest.readAndParseBlobInfo();
+
+        // Set the confirmation block number to be MAX_CERTIFICATE_DRIFT + 1
+        blobVerificationProof.batchMetadata.confirmationBlockNumber = 0;
+
+        vm.roll(101);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ExpiredEigenDACert.selector, 
+                block.number,
+                100
+            )
+        );
+
+        verifier.verifyBlob(
+            blobHeader,
+            blobVerificationProof
+        );
+    }
+
+    function testCertificateWithinSafetyBound() public {
+    (
+        IEigenDAServiceManager.BlobHeader memory blobHeader,
+        EigenDARollupUtils.BlobVerificationProof memory blobVerificationProof
+    ) = inboxTest.readAndParseBlobInfo();
+
+    // Set the confirmation block number to be MAX_CERTIFICATE_DRIFT + 1
+    blobVerificationProof.batchMetadata.confirmationBlockNumber = 100;
+
+    vm.roll(101);
+    vm.expectRevert(bytes(""));
+
+    verifier.verifyBlob(
+        blobHeader,
+        blobVerificationProof
+    );
+    }
+}


### PR DESCRIPTION
**Changes**
- Introduced a vulnerability patch to ensure that the confirmation block number associated with an EigenDA certificate isn't too old or expired
- Only applicable for L2s since L3s can't do any verifications against bridged blob batch commitments 