### PR TITLE
add custom network to hardhat config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -184,6 +184,9 @@ module.exports = {
         ? [process.env['DEVNET_PRIVKEY']]
         : [],
     },
+    custom: {
+      url: process.env['CUSTOM_RPC_URL'] || 'N/A',
+    },
     geth: {
       url: 'http://localhost:8545',
     },


### PR DESCRIPTION
I need this to be able to easily deploy the contracts on a custom test.

these lines already exist on the upstream repo: https://github.com/OffchainLabs/nitro-contracts/blob/v3.1.0/hardhat.config.ts#L206-L208